### PR TITLE
Fixes the issue of missing documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ The asset catalog follows the Isaac Lab asset structure. You can find the asset 
 
 ### Version 0.2.0
 Contains all assets from Version 0.1.0 plus:
-- Pre-trained models for liver scanning (GR00TN1 and GR00TN1_Cosmos, Pi0 model with Cosmos)
+- Pre-trained models for liver scanning:
+  - GR00TN1
+  - GR00TN1_Cosmos
+  - Pi0 model with Cosmos
 - Mira Surgical Robot
 
 Catalog: [v0.2.0](./docs/catalog_v0.2.0.md)


### PR DESCRIPTION
This PR fixes the issue of missing documentation links by adding catalog references and updating the asset lists in the README. 