### PR TITLE
Rename LightWheel to Lightwheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.5.0
 
-- Added LightWheel SimReady Assets.
+- Added Lightwheel SimReady Assets.
 - Added UnitreeG1 humanoid robot.
 - Added Scenes for the Rheo workflow and scene reconstructed by NuRec.
 - Restructured VentionTable into Basic and BlackCover variants.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This asset catalog contains several categories of assets that are essential for 
 
 - **Lightwheel SimReady Assets**: Simulation-ready deformable medical and surgical props powered by [Lightwheel AI](https://www.lightwheel.ai/), including instruments, devices, carts, trays, and scene layouts
 
-> **Note:** The LightWheel SimReady assets included in this catalog are provided for **non-commercial, research and development use only**. These assets are not licensed for commercial usage. Please refer to the `LICENSE.txt` files included with each LightWheel asset for full terms.
+> **Note:** The Lightwheel SimReady assets included in this catalog are provided for **non-commercial, research and development use only**. These assets are not licensed for commercial usage. Please refer to the `LICENSE.txt` files included with each Lightwheel asset for full terms.
 
 ### Configuration Files
 

--- a/catalog.md
+++ b/catalog.md
@@ -54,7 +54,7 @@
 │   │   └── fixture.usda
 │   ├── D405
 │   │   └── D405_blend.usd
-│   ├── Lightwheel
+│   ├── LightWheel
 │   │   ├── Assets
 │   │   │   ├── Box001
 │   │   │   │   ├── Box001.usd

--- a/catalog.md
+++ b/catalog.md
@@ -54,7 +54,7 @@
 │   │   └── fixture.usda
 │   ├── D405
 │   │   └── D405_blend.usd
-│   ├── LightWheel
+│   ├── Lightwheel
 │   │   ├── Assets
 │   │   │   ├── Box001
 │   │   │   │   ├── Box001.usd


### PR DESCRIPTION
This PR renames the brand name "LightWheel" to "Lightwheel" in CHANGELOG.md and README.md. The changes are purely cosmetic/documentation updates with no functional impact.